### PR TITLE
Moved grabber functionality 

### DIFF
--- a/Source/CryptRaider/Grabber.cpp
+++ b/Source/CryptRaider/Grabber.cpp
@@ -32,7 +32,15 @@ void UGrabber::BeginPlay()
 void UGrabber::TickComponent(float DeltaTime, ELevelTick TickType, FActorComponentTickFunction* ThisTickFunction)
 {
 	Super::TickComponent(DeltaTime, TickType, ThisTickFunction);
-	
+}
+
+void UGrabber::Release()
+{
+	UE_LOG(LogTemp, Display, TEXT("Released Grabber"));
+}
+
+void UGrabber::Grab()
+{
 	FVector Start = GetComponentLocation();
 	FVector End = Start + GetForwardVector() * MaxGrabDistance;
 	
@@ -59,5 +67,4 @@ void UGrabber::TickComponent(float DeltaTime, ELevelTick TickType, FActorCompone
 	{
 		UE_LOG(LogTemp, Display, TEXT("No actor hit"));
 	}
-
 }

--- a/Source/CryptRaider/Grabber.h
+++ b/Source/CryptRaider/Grabber.h
@@ -24,6 +24,12 @@ public:
 	// Called every frame
 	virtual void TickComponent(float DeltaTime, ELevelTick TickType, FActorComponentTickFunction* ThisTickFunction) override;
 
+	UFUNCTION(BlueprintCallable)
+	void Release();
+
+	UFUNCTION(BlueprintCallable)
+	void Grab();
+
 private:
 	UPROPERTY(EditAnywhere)
 	float MaxGrabDistance = 400;


### PR DESCRIPTION
Moved grabber functionality into separate function. Removed from tick method and only called on action mapping pressed